### PR TITLE
Remove environmentid from MCP server calls

### DIFF
--- a/libraries/microsoft-agents-a365-tooling-extensions-azureaifoundry/microsoft_agents_a365/tooling/extensions/azureaifoundry/services/mcp_tool_registration_service.py
+++ b/libraries/microsoft-agents-a365-tooling-extensions-azureaifoundry/microsoft_agents_a365/tooling/extensions/azureaifoundry/services/mcp_tool_registration_service.py
@@ -18,7 +18,7 @@ from azure.identity import DefaultAzureCredential
 from azure.ai.agents.models import McpTool, ToolResources
 from microsoft_agents.hosting.core import Authorization, TurnContext
 
-from ...common.utils.utility import get_ppapi_token_scope
+from ...common.utils.utility import get_ppapi_token_scope, get_use_environment_id
 
 # Local imports
 from microsoft_kairo.tooling.common.services.mcp_tool_server_configuration_service import (
@@ -194,7 +194,8 @@ class McpToolRegistrationService:
                 mcp_tool.update_headers(Constants.Headers.AUTHORIZATION, header_value)
 
             # Set environment ID header
-            mcp_tool.update_headers(Constants.Headers.ENVIRONMENT_ID, environment_id)
+            if get_use_environment_id() and environment_id:
+                mcp_tool.update_headers(Constants.Headers.ENVIRONMENT_ID, environment_id)
 
             # Add to collections
             tool_definitions.extend(mcp_tool.definitions)

--- a/libraries/microsoft-agents-a365-tooling-extensions-openai/microsoft_agents_a365/tooling/extensions/openai/mcp_tool_registration_service.py
+++ b/libraries/microsoft-agents-a365-tooling-extensions-openai/microsoft_agents_a365/tooling/extensions/openai/mcp_tool_registration_service.py
@@ -13,7 +13,10 @@ from microsoft_agents_a365.tooling.services.mcp_tool_server_configuration_servic
     McpToolServerConfigurationService,
 )
 
-from microsoft_agents_a365.tooling.utils.utility import get_ppapi_token_scope
+from microsoft_agents_a365.tooling.utils.utility import (
+    get_ppapi_token_scope,
+    get_use_environment_id,
+)
 
 
 # TODO: This is not needed. Remove this.
@@ -114,7 +117,7 @@ class McpToolRegistrationService:
                     headers = si.headers or {}
                     if auth_token:
                         headers["Authorization"] = f"Bearer {auth_token}"
-                    if environment_id:
+                    if get_use_environment_id() and environment_id:
                         headers["x-ms-environment-id"] = environment_id
 
                     # Create MCPServerStreamableHttpParams with proper configuration

--- a/libraries/microsoft-agents-a365-tooling-extensions-semantickernel/microsoft_agents_a365/tooling/extensions/semantickernel/services/mcp_tool_registration_service.py
+++ b/libraries/microsoft-agents-a365-tooling-extensions-semantickernel/microsoft_agents_a365/tooling/extensions/semantickernel/services/mcp_tool_registration_service.py
@@ -24,7 +24,7 @@ from ...common.services.mcp_tool_server_configuration_service import (
 )
 from ...common.models import MCPServerConfig
 from ...common.utils.constants import Constants
-from ...common.utils.utility import get_tools_mode, get_ppapi_token_scope
+from ...common.utils.utility import get_tools_mode, get_ppapi_token_scope, get_use_environment_id
 
 
 from semantic_kernel.connectors.mcp import MCPStreamableHttpPlugin
@@ -135,15 +135,19 @@ class McpToolRegistrationService:
 
                 if tools_mode == "MockMCPServer":
                     # Mock server does not require bearer auth, but still forward environment id if available.
-                    if environment_id:
+                    if get_use_environment_id() and environment_id:
                         headers[Constants.Headers.ENVIRONMENT_ID] = environment_id
 
                     if mock_auth_header := os.getenv("MOCK_MCP_AUTHORIZATION"):
                         headers[Constants.Headers.AUTHORIZATION] = mock_auth_header
-                else:
+                elif get_use_environment_id():
                     headers = {
                         Constants.Headers.AUTHORIZATION: f"{Constants.Headers.BEARER_PREFIX} {auth_token}",
                         Constants.Headers.ENVIRONMENT_ID: environment_id,
+                    }
+                else:
+                    headers = {
+                        Constants.Headers.AUTHORIZATION: f"{Constants.Headers.BEARER_PREFIX} {auth_token}",
                     }
 
                 plugin = MCPStreamableHttpPlugin(

--- a/libraries/microsoft-agents-a365-tooling/microsoft_agents_a365/tooling/services/mcp_tool_server_configuration_service.py
+++ b/libraries/microsoft-agents-a365-tooling/microsoft_agents_a365/tooling/services/mcp_tool_server_configuration_service.py
@@ -30,7 +30,11 @@ import aiohttp
 # Local imports
 from ..models import MCPServerConfig
 from ..utils import Constants
-from ..utils.utility import get_tooling_gateway_for_digital_worker, build_mcp_server_url
+from ..utils.utility import (
+    get_tooling_gateway_for_digital_worker,
+    build_mcp_server_url,
+    get_use_environment_id,
+)
 
 
 # ==============================================================================
@@ -346,9 +350,13 @@ class McpToolServerConfigurationService:
         Returns:
             Dictionary of HTTP headers.
         """
+        if get_use_environment_id():
+            return {
+                "Authorization": f"{Constants.Headers.BEARER_PREFIX} {auth_token}",
+                Constants.Headers.ENVIRONMENT_ID: environment_id,
+            }
         return {
             "Authorization": f"{Constants.Headers.BEARER_PREFIX} {auth_token}",
-            Constants.Headers.ENVIRONMENT_ID: environment_id,
         }
 
     async def _parse_gateway_response(

--- a/libraries/microsoft-agents-a365-tooling/microsoft_agents_a365/tooling/utils/utility.py
+++ b/libraries/microsoft-agents-a365-tooling/microsoft_agents_a365/tooling/utils/utility.py
@@ -50,6 +50,9 @@ def get_mcp_base_url() -> str:
         if tools_mode == ToolsMode.MOCK_MCP_SERVER:
             return os.getenv("MOCK_MCP_SERVER_URL", "http://localhost:5309/mcp-mock/agents/servers")
 
+    if not get_use_environment_id():
+        return f"{_get_mcp_platform_base_url()}/agents/servers"
+
     return f"{_get_mcp_platform_base_url()}/mcp/environments"
 
 
@@ -67,7 +70,9 @@ def build_mcp_server_url(environment_id: str, server_name: str) -> str:
     base_url = get_mcp_base_url()
     environment = _get_current_environment().lower()
 
-    if environment == "development" and base_url.endswith("servers"):
+    if not get_use_environment_id() or (
+        environment == "development" and base_url.endswith("servers")
+    ):
         return f"{base_url}/{server_name}"
     else:
         return f"{base_url}/{environment_id}/servers/{server_name}"
@@ -94,6 +99,17 @@ def _get_mcp_platform_base_url() -> str:
         return os.getenv("MCP_PLATFORM_ENDPOINT")
 
     return MCP_PLATFORM_PROD_BASE_URL
+
+
+def get_use_environment_id() -> bool:
+    """
+    Determines whether to use environment ID in MCP server URL construction.
+
+    Returns:
+        bool: True if environment ID should be used, False otherwise.
+    """
+    use_environment = os.getenv("USE_ENVIRONMENT_ID", "true").lower()
+    return use_environment == "true"
 
 
 def get_tools_mode() -> ToolsMode:


### PR DESCRIPTION
Environment id should no longer need to be passed - service layer will handle routing to MCC environment.