### PR TITLE
Add use env id check to validation and update logs

### DIFF
--- a/libraries/microsoft-agents-a365-tooling-extensions-agentframework/microsoft_agents_a365/tooling/extensions/agentframework/services/mcp_tool_registration_service.py
+++ b/libraries/microsoft-agents-a365-tooling-extensions-agentframework/microsoft_agents_a365/tooling/extensions/agentframework/services/mcp_tool_registration_service.py
@@ -75,9 +75,12 @@ class McpToolRegistrationService:
                 authToken = await auth.exchange_token(turn_context, scopes, "AGENTIC")
                 auth_token = authToken.token
 
-            self._logger.info(
-                f"Listing MCP tool servers for agent {agentic_app_id} in environment {environment_id}"
-            )
+            if get_use_environment_id():
+                self._logger.info(
+                    f"Listing MCP tool servers for agent {agentic_app_id} in environment {environment_id}"
+                )
+            else:
+                self._logger.info(f"Listing MCP tool servers for agent {agentic_app_id}")
 
             # Get MCP server configurations
             server_configs = await self._mcp_server_configuration_service.list_tool_servers(

--- a/libraries/microsoft-agents-a365-tooling-extensions-azureaifoundry/microsoft_agents_a365/tooling/extensions/azureaifoundry/services/mcp_tool_registration_service.py
+++ b/libraries/microsoft-agents-a365-tooling-extensions-azureaifoundry/microsoft_agents_a365/tooling/extensions/azureaifoundry/services/mcp_tool_registration_service.py
@@ -152,9 +152,12 @@ class McpToolRegistrationService:
             return ([], None)
 
         if len(servers) == 0:
-            self._logger.info(
-                f"No MCP servers configured for AgenticAppId={agentic_app_id}, EnvironmentId={environment_id}"
-            )
+            if get_use_environment_id():
+                self._logger.info(
+                    f"No MCP servers configured for AgenticAppId={agentic_app_id}, EnvironmentId={environment_id}"
+                )
+            else:
+                self._logger.info(f"No MCP servers configured for AgenticAppId={agentic_app_id}")
             return ([], None)
 
         # Collections to build for the return value

--- a/libraries/microsoft-agents-a365-tooling-extensions-openai/microsoft_agents_a365/tooling/extensions/openai/mcp_tool_registration_service.py
+++ b/libraries/microsoft-agents-a365-tooling-extensions-openai/microsoft_agents_a365/tooling/extensions/openai/mcp_tool_registration_service.py
@@ -82,9 +82,13 @@ class McpToolRegistrationService:
         # Get MCP server configurations from the configuration service
         # mcp_server_configs = []
         # TODO: radevika: Update once the common project is merged.
-        self._logger.info(
-            f"Listing MCP tool servers for agent {agentic_app_id} in environment {environment_id}"
-        )
+
+        if get_use_environment_id():
+            self._logger.info(
+                f"Listing MCP tool servers for agent {agentic_app_id} in environment {environment_id}"
+            )
+        else:
+            self._logger.info(f"Listing MCP tool servers for agent {agentic_app_id}")
         mcp_server_configs = await self.config_service.list_tool_servers(
             agentic_app_id=agentic_app_id,
             environment_id=environment_id,

--- a/libraries/microsoft-agents-a365-tooling-extensions-semantickernel/microsoft_agents_a365/tooling/extensions/semantickernel/services/mcp_tool_registration_service.py
+++ b/libraries/microsoft-agents-a365-tooling-extensions-semantickernel/microsoft_agents_a365/tooling/extensions/semantickernel/services/mcp_tool_registration_service.py
@@ -185,7 +185,7 @@ class McpToolRegistrationService:
             raise ValueError("kernel cannot be None")
         if not agentic_app_id or not agentic_app_id.strip():
             raise ValueError("agentic_app_id cannot be null or empty")
-        if not environment_id or not environment_id.strip():
+        if get_use_environment_id() and (not environment_id or not environment_id.strip()):
             raise ValueError("environment_id cannot be null or empty")
         if not auth_token or not auth_token.strip():
             raise ValueError("auth_token cannot be null or empty")

--- a/libraries/microsoft-agents-a365-tooling/microsoft_agents_a365/tooling/services/mcp_tool_server_configuration_service.py
+++ b/libraries/microsoft-agents-a365-tooling/microsoft_agents_a365/tooling/services/mcp_tool_server_configuration_service.py
@@ -90,9 +90,12 @@ class McpToolServerConfigurationService:
         # Validate input parameters
         self._validate_input_parameters(agentic_app_id, environment_id, auth_token)
 
-        self._logger.info(
-            f"Listing MCP tool servers for agent {agentic_app_id} in environment {environment_id}"
-        )
+        if get_use_environment_id():
+            self._logger.info(
+                f"Listing MCP tool servers for agent {agentic_app_id} in environment {environment_id}"
+            )
+        else:
+            self._logger.info(f"Listing MCP tool servers for agent {agentic_app_id}")
 
         # Determine configuration source based on environment
         if self._is_development_scenario():
@@ -460,7 +463,7 @@ class McpToolServerConfigurationService:
         """
         if not agentic_app_id:
             raise ValueError("agentic_app_id cannot be empty or None")
-        if not environment_id:
+        if get_use_environment_id() and not environment_id:
             raise ValueError("environment_id cannot be empty or None")
         if not auth_token:
             raise ValueError("auth_token cannot be empty or None")


### PR DESCRIPTION
Validation checks on environment id should only run if the environment id is being used - when the env setting to use enviroment id is disabled, we should skip these checks.
Additionally, updated logs to only log environment info if environment id is being used.