### PR TITLE
Fix AttributeError in notification routing when subchannel is None

### DIFF
--- a/libraries/microsoft-agents-a365-notifications/microsoft_agents_a365/notifications/agent_notification.py
+++ b/libraries/microsoft-agents-a365-notifications/microsoft_agents_a365/notifications/agent_notification.py
@@ -61,10 +61,8 @@ class AgentNotification:
 
         def route_selector(context: TurnContext) -> bool:
             ch = context.activity.channel_id
-            received_channel = ch.channel if ch else ""
-            received_subchannel = ch.sub_channel if ch else ""
-            received_channel = received_channel.lower()
-            received_subchannel = received_subchannel.lower()
+            received_channel = (ch.channel if ch else "").lower()
+            received_subchannel = (ch.sub_channel if ch and ch.sub_channel else "").lower()
             if received_channel != registered_channel:
                 return False
             if registered_subchannel == "*":


### PR DESCRIPTION
The notification routing logic was throwing AttributeError: 'NoneType' object has no attribute 'lower' when processing notifications where ch.sub_channel was None.

The original code checked if ch exists but didn't verify that ch.sub_channel itself was not None before calling .lower()

The fix ensures  .lower() is always called on a string (either the actual value or an empty string), never on None