### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI - Build, Test, and Publish SDKs
 
+permissions:
+  contents: read
+
 # This workflow builds, tests, and publishes Python SDK packages
 # - Builds and tests run on all branches (main, release/*)
 # - Publishing to package repository ONLY happens on release/* branches


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/Agent365-python/security/code-scanning/4](https://github.com/microsoft/Agent365-python/security/code-scanning/4)

To address this issue, add an explicit `permissions` block at the root of the workflow YAML file. This will apply the minimal necessary permissions to all jobs in the workflow, unless overridden at the job level. Since the visible workflow only requires reading contents from the repository, setting `contents: read` is sufficient and aligns with security best practices. Insert the following block right after the `name:` and before `on:` for maximal clarity:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are necessary for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
