### PR TITLE
fix: remove backend-path to resolve ValueError: paths must be inside …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,8 @@ jobs:
     
     - name: Install the project
       run: uv lock && uv sync --locked --all-extras --dev
+      env:
+        PYTHONPATH: ${{ github.workspace }}/versioning/helper
 
     - name: Verify centralized version constraints
       run: uv run --frozen tox -e verify-constraints

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,8 @@ jobs:
     defaults:
       run:
         working-directory: ./
+    env:
+      PYTHONPATH: ${{ github.workspace }}/versioning/helper
 
     strategy:
       matrix:
@@ -105,8 +107,6 @@ jobs:
     
     - name: Install the project
       run: uv lock && uv sync --locked --all-extras --dev
-      env:
-        PYTHONPATH: ${{ github.workspace }}/versioning/helper
 
     - name: Verify centralized version constraints
       run: uv run --frozen tox -e verify-constraints

--- a/libraries/microsoft-agents-a365-notifications/pyproject.toml
+++ b/libraries/microsoft-agents-a365-notifications/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
 build-backend = "build_backend"
-backend-path = ["../../versioning/helper"]
 
 [project]
 name = "microsoft-agents-a365-notifications"

--- a/libraries/microsoft-agents-a365-observability-core/pyproject.toml
+++ b/libraries/microsoft-agents-a365-observability-core/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
 build-backend = "build_backend"
-backend-path = ["../../versioning/helper"]
 
 [project]
 name = "microsoft-agents-a365-observability-core"

--- a/libraries/microsoft-agents-a365-observability-extensions-agentframework/pyproject.toml
+++ b/libraries/microsoft-agents-a365-observability-extensions-agentframework/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
 build-backend = "build_backend"
-backend-path = ["../../versioning/helper"]
 
 [project]
 name = "microsoft-agents-a365-observability-extensions-agent-framework"

--- a/libraries/microsoft-agents-a365-observability-extensions-langchain/pyproject.toml
+++ b/libraries/microsoft-agents-a365-observability-extensions-langchain/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
 build-backend = "build_backend"
-backend-path = ["../../versioning/helper"]
 
 [project]
 name = "microsoft-agents-a365-observability-extensions-langchain"

--- a/libraries/microsoft-agents-a365-observability-extensions-openai/pyproject.toml
+++ b/libraries/microsoft-agents-a365-observability-extensions-openai/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
 build-backend = "build_backend"
-backend-path = ["../../versioning/helper"]
 
 [project]
 name = "microsoft-agents-a365-observability-extensions-openai"

--- a/libraries/microsoft-agents-a365-observability-extensions-semantickernel/pyproject.toml
+++ b/libraries/microsoft-agents-a365-observability-extensions-semantickernel/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
 build-backend = "build_backend"
-backend-path = ["../../versioning/helper"]
 
 [project]
 name = "microsoft-agents-a365-observability-extensions-semantic-kernel"

--- a/libraries/microsoft-agents-a365-observability-hosting/pyproject.toml
+++ b/libraries/microsoft-agents-a365-observability-hosting/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
 build-backend = "build_backend"
-backend-path = ["../../versioning/helper"]
 
 [project]
 name = "microsoft-agents-a365-observability-hosting"

--- a/libraries/microsoft-agents-a365-runtime/pyproject.toml
+++ b/libraries/microsoft-agents-a365-runtime/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
 build-backend = "build_backend"
-backend-path = ["../../versioning/helper"]
 
 [project]
 name = "microsoft-agents-a365-runtime"

--- a/libraries/microsoft-agents-a365-tooling-extensions-agentframework/pyproject.toml
+++ b/libraries/microsoft-agents-a365-tooling-extensions-agentframework/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
 build-backend = "build_backend"
-backend-path = ["../../versioning/helper"]
 
 [project]
 name = "microsoft-agents-a365-tooling-extensions-agentframework"

--- a/libraries/microsoft-agents-a365-tooling-extensions-azureaifoundry/pyproject.toml
+++ b/libraries/microsoft-agents-a365-tooling-extensions-azureaifoundry/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
 build-backend = "build_backend"
-backend-path = ["../../versioning/helper"]
 
 [project]
 name = "microsoft-agents-a365-tooling-extensions-azureaifoundry"

--- a/libraries/microsoft-agents-a365-tooling-extensions-googleadk/pyproject.toml
+++ b/libraries/microsoft-agents-a365-tooling-extensions-googleadk/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
 build-backend = "build_backend"
-backend-path = ["../../versioning/helper"]
 
 [project]
 name = "microsoft-agents-a365-tooling-extensions-googleadk"

--- a/libraries/microsoft-agents-a365-tooling-extensions-openai/pyproject.toml
+++ b/libraries/microsoft-agents-a365-tooling-extensions-openai/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
 build-backend = "build_backend"
-backend-path = ["../../versioning/helper"]
 
 [project]
 name = "microsoft-agents-a365-tooling-extensions-openai"

--- a/libraries/microsoft-agents-a365-tooling-extensions-semantickernel/pyproject.toml
+++ b/libraries/microsoft-agents-a365-tooling-extensions-semantickernel/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
 build-backend = "build_backend"
-backend-path = ["../../versioning/helper"]
 
 [project]
 name = "microsoft-agents-a365-tooling-extensions-semantickernel"

--- a/libraries/microsoft-agents-a365-tooling/pyproject.toml
+++ b/libraries/microsoft-agents-a365-tooling/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
 build-backend = "build_backend"
-backend-path = ["../../versioning/helper"]
 
 [project]
 name = "microsoft-agents-a365-tooling"

--- a/versioning/helper/build_backend.py
+++ b/versioning/helper/build_backend.py
@@ -10,7 +10,7 @@ wheels only from CI.
 
 Usage in package pyproject.toml:
   [build-system]
-  requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit"]
+  requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit", "packaging"]
   build-backend = "build_backend"
 
 The build backend module is resolved via PYTHONPATH, which must include the

--- a/versioning/helper/build_backend.py
+++ b/versioning/helper/build_backend.py
@@ -5,15 +5,20 @@
 Custom build backend that wraps setuptools.build_meta to inject centralized
 version constraints into published wheel metadata.
 
-Note: backend-path references a directory outside the package. This is intentional
-for monorepo wheel builds. Individual sdist publishing is not supported; packages
-are published as wheels only from CI.
+Note: Individual sdist publishing is not supported; packages are published as
+wheels only from CI.
 
 Usage in package pyproject.toml:
   [build-system]
   requires = ["setuptools>=68", "wheel", "tzdata", "tomlkit"]
   build-backend = "build_backend"
-  backend-path = ["../../versioning/helper"]
+
+The build backend module is resolved via PYTHONPATH, which must include the
+path to this directory (versioning/helper) when building. The CI pipeline sets
+this automatically. For local builds, use 'uv build' from the repo root, or
+set PYTHONPATH manually:
+  export PYTHONPATH="$(git rev-parse --show-toplevel)/versioning/helper:$PYTHONPATH"
+  python -m build --no-isolation --wheel
 """
 
 from __future__ import annotations


### PR DESCRIPTION
…source tree

python -m build fails in CI with:
  ValueError: paths must be inside source tree

This is thrown by pyproject_hooks.BuildBackendHookCaller.__init__ which validates that all backend-path entries resolve inside the package source directory. The backend-path = ["../../versioning/helper"] in each package's pyproject.toml points outside the package tree, triggering this check before any build code runs. Setting PYTHONPATH has no effect since the error fires during path validation, not import.

Fix: remove backend-path from all 14 packages. The CI pipeline already exports PYTHONPATH="${ROOT_DIR}/versioning/helper" which makes build_backend importable in the hook subprocess. The custom backend and its S360 version constraint injection are unaffected. uv build from the repo root continues to work for local development.