### PR TITLE
Filter A365 exports to only include genAI spans ADO#37660292

### DIFF
--- a/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/agent365_exporter.py
+++ b/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/agent365_exporter.py
@@ -19,6 +19,7 @@ from opentelemetry.trace import StatusCode
 
 from .utils import (
     DEFAULT_MAX_PAYLOAD_BYTES,
+    INFERENCE_OPERATION_TYPE_NAMES,
     build_export_url,
     chunk_by_size,
     estimate_span_bytes,
@@ -31,6 +32,7 @@ from .utils import (
     status_name,
     truncate_span,
 )
+from ..constants import CHAT_OPERATION_NAME, GEN_AI_OPERATION_NAME_KEY
 
 # ---- Exporter ---------------------------------------------------------------
 
@@ -338,6 +340,14 @@ class _Agent365Exporter(SpanExporter):
 
         # attributes
         attrs = dict(sp.attributes or {})
+
+        # Normalize gen_ai.operation.name from any InferenceOperationType enum
+        # value (Chat, TextCompletion, GenerateContent) to the canonical "chat"
+        # value the ingest service accepts. This is applied only on the export
+        # payload; the underlying span attribute is left untouched.
+        op_name = attrs.get(GEN_AI_OPERATION_NAME_KEY)
+        if isinstance(op_name, str) and op_name in INFERENCE_OPERATION_TYPE_NAMES:
+            attrs[GEN_AI_OPERATION_NAME_KEY] = CHAT_OPERATION_NAME
 
         # events
         events = []

--- a/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/agent365_exporter.py
+++ b/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/agent365_exporter.py
@@ -28,7 +28,7 @@ from .utils import (
     hex_trace_id,
     kind_name,
     parse_retry_after,
-    partition_by_identity,
+    filter_and_partition_by_identity,
     status_name,
     truncate_span,
 )
@@ -81,7 +81,7 @@ class _Agent365Exporter(SpanExporter):
             return SpanExportResult.FAILURE
 
         try:
-            groups = partition_by_identity(spans)
+            groups = filter_and_partition_by_identity(spans)
             if not groups:
                 # No spans with identity; treat as success
                 logger.info("No spans with tenant/agent identity found; nothing exported.")

--- a/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/agent365_exporter.py
+++ b/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/agent365_exporter.py
@@ -32,7 +32,6 @@ from .utils import (
     status_name,
     truncate_span,
 )
-from ..constants import CHAT_OPERATION_NAME, GEN_AI_OPERATION_NAME_KEY
 
 # ---- Exporter ---------------------------------------------------------------
 
@@ -340,14 +339,6 @@ class _Agent365Exporter(SpanExporter):
 
         # attributes
         attrs = dict(sp.attributes or {})
-
-        # Normalize gen_ai.operation.name from any InferenceOperationType enum
-        # value (Chat, TextCompletion, GenerateContent) to the canonical "chat"
-        # value the ingest service accepts. This is applied only on the export
-        # payload; the underlying span attribute is left untouched.
-        op_name = attrs.get(GEN_AI_OPERATION_NAME_KEY)
-        if isinstance(op_name, str) and op_name in INFERENCE_OPERATION_TYPE_NAMES:
-            attrs[GEN_AI_OPERATION_NAME_KEY] = CHAT_OPERATION_NAME
 
         # events
         events = []

--- a/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/agent365_exporter.py
+++ b/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/agent365_exporter.py
@@ -19,7 +19,6 @@ from opentelemetry.trace import StatusCode
 
 from .utils import (
     DEFAULT_MAX_PAYLOAD_BYTES,
-    INFERENCE_OPERATION_TYPE_NAMES,
     build_export_url,
     chunk_by_size,
     estimate_span_bytes,
@@ -83,8 +82,8 @@ class _Agent365Exporter(SpanExporter):
         try:
             groups = filter_and_partition_by_identity(spans)
             if not groups:
-                # No spans with identity; treat as success
-                logger.info("No spans with tenant/agent identity found; nothing exported.")
+                # No eligible genAI spans to export after filtering/partitioning; treat as success
+                logger.info("No eligible genAI spans to export; nothing exported.")
                 return SpanExportResult.SUCCESS
 
             # Log number of groups and total span count

--- a/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/utils.py
+++ b/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/utils.py
@@ -30,9 +30,9 @@ logger = logging.getLogger(__name__)
 # Maximum allowed span size in bytes (250KB)
 MAX_SPAN_SIZE_BYTES = 250 * 1024
 
-# Operation names that identify a span as a genAI span eligible for export to
-# the Agent 365 observability ingest service. Spans without a known
-# gen_ai.operation.name are filtered out of the export batch.
+# Operation names that identify a span as eligible for export to the Agent 365
+# observability ingest service. Only spans whose gen_ai.operation.name matches
+# one of these values are included; all other spans are filtered out.
 GEN_AI_OPERATION_NAMES: frozenset[str] = frozenset(
     {
         INVOKE_AGENT_OPERATION_NAME,
@@ -152,9 +152,10 @@ def filter_and_partition_by_identity(
     """
     Filter export-eligible spans and partition them by (tenantId, agentId).
 
-    Only genAI spans (those with a known ``gen_ai.operation.name``) are
-    included; non-genAI spans (e.g. HTTP, DB) are filtered out. Spans
-    without both tenant and agent identity are also skipped.
+    Only spans whose ``gen_ai.operation.name`` is in
+    ``GEN_AI_OPERATION_NAMES`` are included; non-genAI spans (e.g. HTTP, DB)
+    and spans with other operation names are filtered out. Spans without
+    both tenant and agent identity are also skipped.
     """
     groups: dict[tuple[str, str], list[ReadableSpan]] = {}
     non_gen_ai_count = 0

--- a/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/utils.py
+++ b/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/utils.py
@@ -146,11 +146,11 @@ def truncate_span(span_dict: dict[str, Any]) -> dict[str, Any]:
         return span_dict
 
 
-def partition_by_identity(
+def filter_and_partition_by_identity(
     spans: Sequence[ReadableSpan],
 ) -> dict[tuple[str, str], list[ReadableSpan]]:
     """
-    Partition spans by (tenantId, agentId).
+    Filter export-eligible spans and partition them by (tenantId, agentId).
 
     Only genAI spans (those with a known ``gen_ai.operation.name``) are
     included; non-genAI spans (e.g. HTTP, DB) are filtered out. Spans
@@ -174,17 +174,15 @@ def partition_by_identity(
         groups.setdefault(key, []).append(sp)
 
     if non_gen_ai_count > 0:
-        logger.info(f"[Agent365Exporter] {non_gen_ai_count} non-genAI spans filtered out")
+        logger.debug(
+            f"[Agent365Exporter] {non_gen_ai_count} spans without an eligible "
+            "gen_ai.operation.name filtered out"
+        )
     if missing_identity_count > 0:
-        logger.warning(
+        logger.debug(
             f"[Agent365Exporter] {missing_identity_count} spans skipped due to "
             "missing tenant or agent ID"
         )
-    skipped = non_gen_ai_count + missing_identity_count
-    logger.info(
-        f"[Agent365Exporter] Partitioned into {len(groups)} identity groups "
-        f"({skipped} spans skipped)"
-    )
     return groups
 
 

--- a/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/utils.py
+++ b/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/utils.py
@@ -175,14 +175,12 @@ def filter_and_partition_by_identity(
 
     if non_gen_ai_count > 0:
         logger.debug(
-            "[Agent365Exporter] %d spans without an eligible "
-            "gen_ai.operation.name filtered out",
+            "[Agent365Exporter] %d spans without an eligible gen_ai.operation.name filtered out",
             non_gen_ai_count,
         )
     if missing_identity_count > 0:
         logger.debug(
-            "[Agent365Exporter] %d spans skipped due to "
-            "missing tenant or agent ID",
+            "[Agent365Exporter] %d spans skipped due to missing tenant or agent ID",
             missing_identity_count,
         )
     return groups

--- a/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/utils.py
+++ b/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/utils.py
@@ -175,13 +175,15 @@ def filter_and_partition_by_identity(
 
     if non_gen_ai_count > 0:
         logger.debug(
-            f"[Agent365Exporter] {non_gen_ai_count} spans without an eligible "
-            "gen_ai.operation.name filtered out"
+            "[Agent365Exporter] %d spans without an eligible "
+            "gen_ai.operation.name filtered out",
+            non_gen_ai_count,
         )
     if missing_identity_count > 0:
         logger.debug(
-            f"[Agent365Exporter] {missing_identity_count} spans skipped due to "
-            "missing tenant or agent ID"
+            "[Agent365Exporter] %d spans skipped due to "
+            "missing tenant or agent ID",
+            missing_identity_count,
         )
     return groups
 

--- a/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/utils.py
+++ b/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/utils.py
@@ -40,18 +40,6 @@ GEN_AI_OPERATION_NAMES: frozenset[str] = frozenset(
         OUTPUT_MESSAGES_OPERATION_NAME,
         CHAT_OPERATION_NAME,
         InferenceOperationType.CHAT.value,
-        InferenceOperationType.TEXT_COMPLETION.value,
-        InferenceOperationType.GENERATE_CONTENT.value,
-    }
-)
-
-# Inference operation type values that the ingest service expects to be
-# normalized to the canonical "chat" gen_ai.operation.name.
-INFERENCE_OPERATION_TYPE_NAMES: frozenset[str] = frozenset(
-    {
-        InferenceOperationType.CHAT.value,
-        InferenceOperationType.TEXT_COMPLETION.value,
-        InferenceOperationType.GENERATE_CONTENT.value,
     }
 )
 

--- a/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/utils.py
+++ b/libraries/microsoft-agents-a365-observability-core/microsoft_agents_a365/observability/core/exporters/utils.py
@@ -14,15 +14,46 @@ from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.trace import SpanKind, StatusCode
 
 from ..constants import (
+    CHAT_OPERATION_NAME,
     ENABLE_A365_OBSERVABILITY_EXPORTER,
+    EXECUTE_TOOL_OPERATION_NAME,
     GEN_AI_AGENT_ID_KEY,
+    GEN_AI_OPERATION_NAME_KEY,
+    INVOKE_AGENT_OPERATION_NAME,
+    OUTPUT_MESSAGES_OPERATION_NAME,
     TENANT_ID_KEY,
 )
+from ..inference_operation_type import InferenceOperationType
 
 logger = logging.getLogger(__name__)
 
 # Maximum allowed span size in bytes (250KB)
 MAX_SPAN_SIZE_BYTES = 250 * 1024
+
+# Operation names that identify a span as a genAI span eligible for export to
+# the Agent 365 observability ingest service. Spans without a known
+# gen_ai.operation.name are filtered out of the export batch.
+GEN_AI_OPERATION_NAMES: frozenset[str] = frozenset(
+    {
+        INVOKE_AGENT_OPERATION_NAME,
+        EXECUTE_TOOL_OPERATION_NAME,
+        OUTPUT_MESSAGES_OPERATION_NAME,
+        CHAT_OPERATION_NAME,
+        InferenceOperationType.CHAT.value,
+        InferenceOperationType.TEXT_COMPLETION.value,
+        InferenceOperationType.GENERATE_CONTENT.value,
+    }
+)
+
+# Inference operation type values that the ingest service expects to be
+# normalized to the canonical "chat" gen_ai.operation.name.
+INFERENCE_OPERATION_TYPE_NAMES: frozenset[str] = frozenset(
+    {
+        InferenceOperationType.CHAT.value,
+        InferenceOperationType.TEXT_COMPLETION.value,
+        InferenceOperationType.GENERATE_CONTENT.value,
+    }
+)
 
 
 def hex_trace_id(value: int) -> str:
@@ -131,18 +162,41 @@ def partition_by_identity(
     spans: Sequence[ReadableSpan],
 ) -> dict[tuple[str, str], list[ReadableSpan]]:
     """
-    Extract (tenantId, agentId). Prefer attributes; if you also stamp baggage
-    into attributes via a processor, they'll be here already.
+    Partition spans by (tenantId, agentId).
+
+    Only genAI spans (those with a known ``gen_ai.operation.name``) are
+    included; non-genAI spans (e.g. HTTP, DB) are filtered out. Spans
+    without both tenant and agent identity are also skipped.
     """
     groups: dict[tuple[str, str], list[ReadableSpan]] = {}
+    non_gen_ai_count = 0
+    missing_identity_count = 0
     for sp in spans:
         attrs = sp.attributes or {}
+        operation_name = as_str(attrs.get(GEN_AI_OPERATION_NAME_KEY))
+        if not operation_name or operation_name not in GEN_AI_OPERATION_NAMES:
+            non_gen_ai_count += 1
+            continue
         tenant = as_str(attrs.get(TENANT_ID_KEY))
         agent = as_str(attrs.get(GEN_AI_AGENT_ID_KEY))
         if not tenant or not agent:
+            missing_identity_count += 1
             continue
         key = (tenant, agent)
         groups.setdefault(key, []).append(sp)
+
+    if non_gen_ai_count > 0:
+        logger.info(f"[Agent365Exporter] {non_gen_ai_count} non-genAI spans filtered out")
+    if missing_identity_count > 0:
+        logger.warning(
+            f"[Agent365Exporter] {missing_identity_count} spans skipped due to "
+            "missing tenant or agent ID"
+        )
+    skipped = non_gen_ai_count + missing_identity_count
+    logger.info(
+        f"[Agent365Exporter] Partitioned into {len(groups)} identity groups "
+        f"({skipped} spans skipped)"
+    )
     return groups
 
 

--- a/tests/observability/core/exporters/test_payload_chunking.py
+++ b/tests/observability/core/exporters/test_payload_chunking.py
@@ -10,7 +10,9 @@ import unittest
 from unittest.mock import Mock, patch
 
 from microsoft_agents_a365.observability.core.constants import (
+    CHAT_OPERATION_NAME,
     GEN_AI_AGENT_ID_KEY,
+    GEN_AI_OPERATION_NAME_KEY,
     TENANT_ID_KEY,
 )
 from microsoft_agents_a365.observability.core.exporters.agent365_exporter import (
@@ -165,6 +167,7 @@ class TestExporterChunking(unittest.TestCase):
         mock_span.attributes = {
             TENANT_ID_KEY: "tenant-1",
             GEN_AI_AGENT_ID_KEY: "agent-1",
+            GEN_AI_OPERATION_NAME_KEY: CHAT_OPERATION_NAME,
             "payload": "x" * attribute_size,
         }
         mock_span.events = []

--- a/tests/observability/core/test_agent365_exporter.py
+++ b/tests/observability/core/test_agent365_exporter.py
@@ -358,9 +358,9 @@ class TestAgent365Exporter(unittest.TestCase):
         # Verify export succeeded (no identity spans are treated as success)
         self.assertEqual(result, SpanExportResult.SUCCESS)
 
-        # Verify info log for no identity
+        # Verify info log for no eligible spans
         mock_logger.info.assert_called_with(
-            "No spans with tenant/agent identity found; nothing exported."
+            "No eligible genAI spans to export; nothing exported."
         )
 
     def test_exporter_is_internal(self):

--- a/tests/observability/core/test_agent365_exporter.py
+++ b/tests/observability/core/test_agent365_exporter.py
@@ -6,7 +6,12 @@ import os
 import unittest
 from unittest.mock import Mock, patch
 
-from microsoft_agents_a365.observability.core.constants import GEN_AI_AGENT_ID_KEY, TENANT_ID_KEY
+from microsoft_agents_a365.observability.core.constants import (
+    GEN_AI_AGENT_ID_KEY,
+    GEN_AI_OPERATION_NAME_KEY,
+    INVOKE_AGENT_OPERATION_NAME,
+    TENANT_ID_KEY,
+)
 from microsoft_agents_a365.observability.core.exporters.agent365_exporter import (
     DEFAULT_ENDPOINT_URL,
     _Agent365Exporter,
@@ -54,6 +59,7 @@ class TestAgent365Exporter(unittest.TestCase):
         scope_version: str = "1.0.0",
         tenant_id: str = "test-tenant-123",
         agent_id: str = "test-agent-456",
+        operation_name: str | None = INVOKE_AGENT_OPERATION_NAME,
     ) -> ReadableSpan:
         """Create a mock ReadableSpan for testing."""
         mock_span = Mock(spec=ReadableSpan)
@@ -85,6 +91,8 @@ class TestAgent365Exporter(unittest.TestCase):
                 TENANT_ID_KEY: tenant_id,
                 GEN_AI_AGENT_ID_KEY: agent_id,
             })
+        if operation_name is not None and GEN_AI_OPERATION_NAME_KEY not in span_attributes:
+            span_attributes[GEN_AI_OPERATION_NAME_KEY] = operation_name
 
         mock_span.attributes = span_attributes
         mock_span.events = []
@@ -656,6 +664,89 @@ class TestAgent365Exporter(unittest.TestCase):
             # Assert
             self.assertEqual(result, SpanExportResult.SUCCESS)
             mock_post.assert_called_once()
+
+    def test_export_filters_out_non_genai_spans(self):
+        """Spans without a known gen_ai.operation.name are filtered out."""
+        # Arrange: one genAI span and two non-genAI spans (no/unknown operation name)
+        genai_span = self._create_mock_span("genai_span", trace_id=1, span_id=2)
+        no_op_span = self._create_mock_span("http_span", trace_id=3, span_id=4, operation_name=None)
+        unknown_op_span = self._create_mock_span(
+            "db_span", trace_id=5, span_id=6, operation_name="some_random_op"
+        )
+
+        with patch.object(self.exporter, "_post_with_retries", return_value=True) as mock_post:
+            # Act
+            result = self.exporter.export([genai_span, no_op_span, unknown_op_span])
+
+            # Assert: only the genAI span is exported
+            self.assertEqual(result, SpanExportResult.SUCCESS)
+            mock_post.assert_called_once()
+            _, body, _ = mock_post.call_args[0]
+            request_data = json.loads(body)
+            spans_out = request_data["resourceSpans"][0]["scopeSpans"][0]["spans"]
+            self.assertEqual(len(spans_out), 1)
+            self.assertEqual(spans_out[0]["name"], "genai_span")
+
+    def test_export_filters_out_only_non_genai_spans_returns_success(self):
+        """When all spans are filtered out, export returns SUCCESS without HTTP call."""
+        # Arrange
+        spans = [
+            self._create_mock_span("http_span", operation_name=None),
+            self._create_mock_span("db_span", operation_name="other"),
+        ]
+
+        with patch.object(self.exporter, "_post_with_retries", return_value=True) as mock_post:
+            # Act
+            result = self.exporter.export(spans)
+
+            # Assert
+            self.assertEqual(result, SpanExportResult.SUCCESS)
+            mock_post.assert_not_called()
+
+    def test_export_includes_inference_operation_type_spans(self):
+        """Spans with InferenceOperationType enum values are kept and normalized."""
+        # Arrange
+        chat_span = self._create_mock_span(
+            "chat_span", trace_id=1, span_id=2, operation_name="Chat"
+        )
+        text_completion_span = self._create_mock_span(
+            "text_completion_span", trace_id=3, span_id=4, operation_name="TextCompletion"
+        )
+        generate_content_span = self._create_mock_span(
+            "generate_content_span", trace_id=5, span_id=6, operation_name="GenerateContent"
+        )
+
+        with patch.object(self.exporter, "_post_with_retries", return_value=True) as mock_post:
+            # Act
+            result = self.exporter.export([chat_span, text_completion_span, generate_content_span])
+
+            # Assert: all three are exported and normalized to "chat"
+            self.assertEqual(result, SpanExportResult.SUCCESS)
+            mock_post.assert_called_once()
+            _, body, _ = mock_post.call_args[0]
+            request_data = json.loads(body)
+            spans_out = request_data["resourceSpans"][0]["scopeSpans"][0]["spans"]
+            self.assertEqual(len(spans_out), 3)
+            for span in spans_out:
+                self.assertEqual(span["attributes"]["gen_ai.operation.name"], "chat")
+
+    def test_export_does_not_normalize_canonical_operation_names(self):
+        """invoke_agent / execute_tool / output_messages / chat are not rewritten."""
+        cases = ["invoke_agent", "execute_tool", "output_messages", "chat"]
+        for op in cases:
+            with self.subTest(operation_name=op):
+                span = self._create_mock_span(
+                    f"{op}_span", trace_id=1, span_id=2, operation_name=op
+                )
+                with patch.object(
+                    self.exporter, "_post_with_retries", return_value=True
+                ) as mock_post:
+                    result = self.exporter.export([span])
+                    self.assertEqual(result, SpanExportResult.SUCCESS)
+                    _, body, _ = mock_post.call_args[0]
+                    request_data = json.loads(body)
+                    span_out = request_data["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+                    self.assertEqual(span_out["attributes"]["gen_ai.operation.name"], op)
 
 
 if __name__ == "__main__":

--- a/tests/observability/core/test_agent365_exporter.py
+++ b/tests/observability/core/test_agent365_exporter.py
@@ -359,9 +359,7 @@ class TestAgent365Exporter(unittest.TestCase):
         self.assertEqual(result, SpanExportResult.SUCCESS)
 
         # Verify info log for no eligible spans
-        mock_logger.info.assert_called_with(
-            "No eligible genAI spans to export; nothing exported."
-        )
+        mock_logger.info.assert_called_with("No eligible genAI spans to export; nothing exported.")
 
     def test_exporter_is_internal(self):
         """Test that _Agent365Exporter is marked as internal/private.

--- a/tests/observability/core/test_agent365_exporter.py
+++ b/tests/observability/core/test_agent365_exporter.py
@@ -703,12 +703,27 @@ class TestAgent365Exporter(unittest.TestCase):
             self.assertEqual(result, SpanExportResult.SUCCESS)
             mock_post.assert_not_called()
 
-    def test_export_includes_inference_operation_type_spans(self):
-        """Spans with InferenceOperationType enum values are kept and normalized."""
-        # Arrange
+    def test_export_includes_inference_operation_type_chat_spans(self):
+        """Spans with InferenceOperationType.CHAT value ('Chat') are kept without normalization."""
+        # Arrange — server accepts 'Chat' via case-insensitive matching
         chat_span = self._create_mock_span(
             "chat_span", trace_id=1, span_id=2, operation_name="Chat"
         )
+
+        with patch.object(self.exporter, "_post_with_retries", return_value=True) as mock_post:
+            result = self.exporter.export([chat_span])
+
+            self.assertEqual(result, SpanExportResult.SUCCESS)
+            mock_post.assert_called_once()
+            _, body, _ = mock_post.call_args[0]
+            request_data = json.loads(body)
+            spans_out = request_data["resourceSpans"][0]["scopeSpans"][0]["spans"]
+            self.assertEqual(len(spans_out), 1)
+            # Value is preserved as-is; no normalization
+            self.assertEqual(spans_out[0]["attributes"]["gen_ai.operation.name"], "Chat")
+
+    def test_export_filters_out_unsupported_inference_operation_types(self):
+        """Spans with TextCompletion / GenerateContent are filtered out."""
         text_completion_span = self._create_mock_span(
             "text_completion_span", trace_id=3, span_id=4, operation_name="TextCompletion"
         )
@@ -717,18 +732,11 @@ class TestAgent365Exporter(unittest.TestCase):
         )
 
         with patch.object(self.exporter, "_post_with_retries", return_value=True) as mock_post:
-            # Act
-            result = self.exporter.export([chat_span, text_completion_span, generate_content_span])
+            result = self.exporter.export([text_completion_span, generate_content_span])
 
-            # Assert: all three are exported and normalized to "chat"
+            # Both are filtered out — nothing to export
             self.assertEqual(result, SpanExportResult.SUCCESS)
-            mock_post.assert_called_once()
-            _, body, _ = mock_post.call_args[0]
-            request_data = json.loads(body)
-            spans_out = request_data["resourceSpans"][0]["scopeSpans"][0]["spans"]
-            self.assertEqual(len(spans_out), 3)
-            for span in spans_out:
-                self.assertEqual(span["attributes"]["gen_ai.operation.name"], "chat")
+            mock_post.assert_not_called()
 
     def test_export_does_not_normalize_canonical_operation_names(self):
         """invoke_agent / execute_tool / output_messages / chat are not rewritten."""

--- a/tests/observability/core/test_agent365_exporter.py
+++ b/tests/observability/core/test_agent365_exporter.py
@@ -84,7 +84,7 @@ class TestAgent365Exporter(unittest.TestCase):
         mock_span.kind = Mock()
         mock_span.kind.name = "INTERNAL"
 
-        # Add identity attributes for partition_by_identity to work
+        # Add identity attributes for filter_and_partition_by_identity to work
         span_attributes = attributes or {}
         if tenant_id and agent_id:
             span_attributes.update({

--- a/tests/observability/core/test_agent365_exporter.py
+++ b/tests/observability/core/test_agent365_exporter.py
@@ -720,7 +720,7 @@ class TestAgent365Exporter(unittest.TestCase):
             spans_out = request_data["resourceSpans"][0]["scopeSpans"][0]["spans"]
             self.assertEqual(len(spans_out), 1)
             # Value is preserved as-is; no normalization
-            self.assertEqual(spans_out[0]["attributes"]["gen_ai.operation.name"], "Chat")
+            self.assertEqual(spans_out[0]["attributes"][GEN_AI_OPERATION_NAME_KEY], "Chat")
 
     def test_export_filters_out_unsupported_inference_operation_types(self):
         """Spans with TextCompletion / GenerateContent are filtered out."""
@@ -754,7 +754,7 @@ class TestAgent365Exporter(unittest.TestCase):
                     _, body, _ = mock_post.call_args[0]
                     request_data = json.loads(body)
                     span_out = request_data["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
-                    self.assertEqual(span_out["attributes"]["gen_ai.operation.name"], op)
+                    self.assertEqual(span_out["attributes"][GEN_AI_OPERATION_NAME_KEY], op)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Filter A365 exports to only include genAI spans
ADO#37660292 [Task 37660292](https://msazure.visualstudio.com/OneAgile/_workitems/edit/37660292): [Python] Ensure a365 exports only genAI spans